### PR TITLE
Allow Action Definitions to be called as functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const FlipTable = TypedAction.define("app::flip_table")<{
 //      payload: { tableId: "2567f216-59b7-4bfe-b46f-909c6711fea4", face: "happy" }
 //    }
 //
-const action = FlipTable.create({
+const action = FlipTable({
   tableId: "2567f216-59b7-4bfe-b46f-909c6711fea4",
   face: "happy"
 });
@@ -115,7 +115,7 @@ import { CompoundAction } from "redoodle";
 const doFoo: Action = {...};
 const doBar: Action = {...};
 
-store.dispatch(CompoundAction.create([doFoo, doBar]));
+store.dispatch(CompoundAction([doFoo, doBar]));
 ```
 
 To use CompoundActions, your store must be configured to correctly unwrap and reduce them; thankfully Redoodle

--- a/docs/actions/CreatingDefinition.md
+++ b/docs/actions/CreatingDefinition.md
@@ -33,6 +33,7 @@ export namespace TypedAction {
       <T>() => Definition<E, T>;
 
   interface Definition<E extends string, T> {
+    (payload: T): {type: E; payload: T;};
     create(payload: T): {type: E; payload: T;};
     is(action: Action): action is TypedAction<T, E>;
     TYPE: TypedActionString<T, E>;

--- a/docs/actions/UsingDefinitionCreate.md
+++ b/docs/actions/UsingDefinitionCreate.md
@@ -3,9 +3,9 @@
 The most important thing a Definition does is to be a factory to stamp
 instances of Actions that conform to the Definition.
 
-A Definition has a method `create()` which, given a payload,
+A Definition is a callable function which, given a payload,
 will create an Action object ready to dispatch.
-The `create()` method is typesafe, which means that a payload
+The Definition itself is typesafe, which means that a payload
 that has incorrect, has extra, or is missing keys will raise compile-time errors.
 
 The created Action is a plain old Redux Action that's ready to go straight
@@ -27,7 +27,7 @@ const AddMessage = TypedAction.define("chatroom::add_message")<{
   author: string;
 }>();
 
-const action = AddMessage.create({
+const action = AddMessage({
   message: "Hello Redoodle",
   author: "crazytoucan"
 });
@@ -54,7 +54,12 @@ const action = AddMessage.create({
 ```ts
 namespace TypedAction {
   interface Definition<E extends string, T> {
+    (payload: T): {type: E; payload: T;};
+
+    // other members not explored in this segment
     create(payload: T): {type: E; payload: T;};
+    is(action: Action): action is TypedAction<T, E>;
+    TYPE: TypedActionString<T, E>;
   }
 }
 ```

--- a/docs/actions/UsingDefinitionIs.md
+++ b/docs/actions/UsingDefinitionIs.md
@@ -41,6 +41,11 @@ if (AddMessage.is(action)) {
 namespace TypedAction {
   interface Definition<E extends string, T> {
     is(action: Action): action is TypedAction<T, E>;
+
+    // other members not explored in this segment
+    (payload: T): {type: E; payload: T;};
+    create(payload: T): {type: E; payload: T;};
+    TYPE: TypedActionString<T, E>;
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "lint": "find src -type f | xargs tslint -c tslint.json",
-    "prepare": "npm run clean && npm run build",
-    "test": "jest && npm run lint",
-    "build": "npm run clean && tsc",
+    "prepare": "yarn run clean && yarn run build",
+    "test": "jest && yarn run lint",
+    "build": "yarn run clean && tsc",
     "clean": "rm -rf lib/",
     "docs:clean": "rm -rf _book/",
     "docs:prepare": "gitbook install",
-    "docs:build": "npm run docs:prepare && gitbook build -g palantir/redoodle",
-    "docs:watch": "npm run docs:prepare && gitbook serve -g palantir/redoodle",
-    "docs:publish": "npm run docs:clean && npm run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:palantir/redoodle gh-pages --force"
+    "docs:build": "yarn run docs:prepare && gitbook build -g palantir/redoodle",
+    "docs:watch": "yarn run docs:prepare && gitbook serve -g palantir/redoodle",
+    "docs:publish": "yarn run docs:clean && yarn run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:palantir/redoodle gh-pages --force"
   },
   "dependencies": {
     "tslib": "^1.6.1"

--- a/src/__tests__/TypedAction.spec.ts
+++ b/src/__tests__/TypedAction.spec.ts
@@ -24,6 +24,30 @@ describe("TypedAction", () => {
       SetMessage = TypedAction.define("test::set_message")<string>();
     });
 
+    describe("when called as function, the returned action", () => {
+      let action: TypedAction<string>;
+      beforeAll(() => {
+        action = SetMessage("Hello World");
+      });
+
+      it("should have defined type", () => {
+        expect(action).toBeDefined();
+        expect(action.type).toEqual(SetMessage.TYPE);
+      });
+
+      it("should have given payload", () => {
+        expect(action.payload).toEqual("Hello World");
+      });
+
+      it("should return actions with correct typing information", () => {
+        expect(typeof action.payload.charAt).toBe("function");
+      });
+
+      it("should return actions without a 'meta' key", () => {
+        expect(action).not.toHaveProperty("meta");
+      });
+    });
+
     describe("#TYPE", () => {
       it("should match", () => {
         expect(SetMessage.TYPE).toBe("test::set_message");
@@ -112,6 +136,30 @@ describe("TypedAction", () => {
       });
     });
 
+    describe("when called as function (validation pass), the returned action", () => {
+      let action: TypedAction<string>;
+      beforeAll(() => {
+        action = SetMessage("Hello World");
+      });
+
+      it("should have defined type", () => {
+        expect(action).toBeDefined();
+        expect(action.type).toEqual(SetMessage.TYPE);
+      });
+
+      it("should have given payload", () => {
+        expect(action.payload).toEqual("Hello World");
+      });
+
+      it("should return actions with correct typing information", () => {
+        expect(typeof action.payload.charAt).toBe("function");
+      });
+
+      it("should return actions without a 'meta' key when no meta is provided", () => {
+        expect(action).not.toHaveProperty("meta");
+      });
+    });
+
     describe("#TYPE", () => {
       it("should match", () => {
         expect(SetMessage.TYPE).toBe("test::set_message");
@@ -139,6 +187,14 @@ describe("TypedAction", () => {
 
       it("should return actions without a 'meta' key when no meta is provided", () => {
         expect(action).not.toHaveProperty("meta");
+      });
+    });
+
+    describe("when called as function (validation fail)", () => {
+      it("should throw", () => {
+        expect(() => {
+          SetMessage("blacklist");
+        }).toThrow();
       });
     });
 


### PR DESCRIPTION
This PR improves ergonomics for `Definition.create()`:

```ts
const SetVisible = TypedAction.create("app::set_visible")<{
  item: string;
}>();

// old way
dispatch(SetVisible.create({ item: "hello-redoodle" }));

// new way
dispatch(SetVisible({ item: "hello-redoodle" }));
```