### PR TITLE
Add PayloadOf<> helper.

### DIFF
--- a/src/TypedAction.ts
+++ b/src/TypedAction.ts
@@ -78,6 +78,7 @@ export interface TypedAction<T, E extends string = string> {
 }
 
 export namespace TypedAction {
+
   /**
    * Options to TypedAction.define().
    */
@@ -192,6 +193,8 @@ export namespace TypedAction {
      */
     is(action: Action): action is TypedAction<T, E>;
   }
+
+  export type PayloadOf<D extends Definition<any, any>> = D["TYPE"]["__type__"]["withPayload"];
 
   /**
    * A TypedAction.NoPayloadDefinition manages all Redux actions of a specific type string,


### PR DESCRIPTION
This helper should improve working with raw action payloads, without needing to create separate payload types for every action.

```ts
const SetVisible = TypedAction.create("app::set_visible")<{
  item: string;
}>();

function acceptSetVisible(payload: TypedAction.PayloadOf<typeof SetVisible>) {
  console.log(payload.item);
}
```
