### PR TITLE
Use Pick | S instead of Pick & Partial.

### DIFF
--- a/src/setWith.ts
+++ b/src/setWith.ts
@@ -44,8 +44,8 @@ import { shallowEqualsPartial } from "./internal/utils/shallowEqualsPartial";
  */
 export function setWith<S, K extends keyof S>(
   state: S,
-  override: (Partial<S> & Pick<S, K>),
-  ...addlOverrides: (Partial<S> & Pick<S, K>)[],
+  override: (Pick<S, K> | S),
+  ...addlOverrides: (Pick<S, K> | S)[],
 ): S;
 
 /**


### PR DESCRIPTION
`Pick<S, K>` doesn't offer any autocomplete in VSCode, so the original fix was to type `setWith()` `Pick<S, K> & Partial<S>` to trick the autocomplete. @ericanderson has found a better approach using `Pick | S`, which comes with much less jank in my opinion.