### PR TITLE
update setWith typings to allow partial overrides

### DIFF
--- a/src/setWith.ts
+++ b/src/setWith.ts
@@ -44,8 +44,8 @@ import { shallowEqualsPartial } from "./internal/utils/shallowEqualsPartial";
  */
 export function setWith<S, K extends keyof S>(
   state: S,
-  override: (Pick<S, K> | S),
-  ...addlOverrides: (Pick<S, K> | S)[],
+  override: (Pick<S, K> | S | Partial<S>),
+  ...addlOverrides: (Pick<S, K> | S | Partial<S>)[],
 ): S;
 
 /**


### PR DESCRIPTION
Current `setWith` typings do not allow for the override parameter to be a Partial of the state parameter.

For example:
```
private updateProps = (userState: Partial<IUserState>) =>
    this.setState({ user: setWith(this.state.user, userState) });
```

This PR adds `Partial<S>` to the type of override.