### PR TITLE
Add "sideEffects": false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An addon library for Redux that enhances its integration with TypeScript.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "lint": "find src -type f | xargs tslint -c tslint.json",
     "prepare": "yarn run clean && yarn run build",


### PR DESCRIPTION
Per https://webpack.js.org/guides/tree-shaking/ , the `"sideEffects"` flag is used to discern which transitively imported files can be dropped for tree-shaking. In Redoodle's case, there are no side effects of any module imports.