### PR TITLE
Upgrade to TypeScript 3.8.3, tslib 1.8.1, tslint 5.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:publish": "yarn run docs:clean && yarn run docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:palantir/redoodle gh-pages --force"
   },
   "dependencies": {
-    "tslib": "^1.6.1"
+    "tslib": "^1.8.1"
   },
   "devDependencies": {
     "@types/jest": "^19.2.2",
@@ -26,9 +26,9 @@
     "jest": "^19.0.2",
     "redux": "^4.0.0",
     "ts-jest": "^19.0.13",
-    "tslint": "^5.1.0",
+    "tslint": "^5.11.0",
     "tslint-eslint-rules": "^4.0.0",
-    "typescript": "^2.4.2"
+    "typescript": "^3.8.3"
   },
   "jest": {
     "transform": {

--- a/src/__tests__/composeReducers.spec.ts
+++ b/src/__tests__/composeReducers.spec.ts
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-import { Action, TypedAction, composeReducers } from "../index";
+import { Action, composeReducers } from "../index";
 
-function add(state: number, action: TypedAction<number>) {
+function add(state: number, action: Action) {
   return state + action.payload;
 }
 
-function multiply(state: number, action: TypedAction<number>) {
+function multiply(state: number, action: Action) {
   return state * action.payload;
 }
 
 function constant(payload: number): Action {
-  return {type: "test::constant", payload};
+  return { type: "test::constant", payload };
 }
 
 describe("composeReducers", () => {

--- a/src/internal/TypedReducerBuilderImpl.ts
+++ b/src/internal/TypedReducerBuilderImpl.ts
@@ -23,7 +23,7 @@ import { TypedReducer } from "../TypedReducer";
 
 export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
   private typedHandlers: {[type: string]: Reducer<S>} = {};
-  private defaultHandler: Reducer<S>;
+  private defaultHandler: Reducer<S> | undefined;
 
   withHandler<T>(
     type: TypedActionString<T>,
@@ -47,7 +47,7 @@ export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
       }
     }
 
-    this.typedHandlers[type as string] = handler;
+    this.typedHandlers[type as string] = handler as Reducer<S>;
     return this;
   }
 

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -41,7 +41,7 @@ function anyDefined(state: any, keys: string[]): boolean {
  *      a prototype if the input `state` has no prototype.
  */
 export function omit<S extends {[key: string]: any}>(state: S, keys: (keyof S)[]): S {
-  if (!anyDefined(state, keys)) {
+  if (!anyDefined(state, keys as string[])) {
     return state;
   }
 

--- a/src/setWith.ts
+++ b/src/setWith.ts
@@ -44,8 +44,8 @@ import { shallowEqualsPartial } from "./internal/utils/shallowEqualsPartial";
  */
 export function setWith<S, K extends keyof S>(
   state: S,
-  override: (Pick<S, K> | S),
-  ...addlOverrides: (Pick<S, K> | S)[],
+  override: Pick<S, K> | S,
+  ...addlOverrides: (Pick<S, K> | S)[] // tslint:disable-line:trailing-comma
 ): S;
 
 /**
@@ -75,7 +75,7 @@ export function setWith<S, K extends keyof S>(
 export function setWith<S extends Record<string, any>>(
   state: S,
   override: S,
-  ...addlOverrides: S[],
+  ...addlOverrides: S[] // tslint:disable-line:trailing-comma
 ): S;
 
 export function setWith(state: any, ...overrides: any[]) {
@@ -83,10 +83,18 @@ export function setWith(state: any, ...overrides: any[]) {
     if (shallowEqualsPartial(state, overrides[0])) {
       return state;
     } else {
-      return __assign(Object.create(Object.getPrototypeOf(state)), state, overrides[0]);
+      return __assign(
+        Object.create(Object.getPrototypeOf(state)),
+        state,
+        overrides[0],
+      );
     }
   } else {
-    const result = __assign(Object.create(Object.getPrototypeOf(state)), state, ...overrides);
+    const result = __assign(
+      Object.create(Object.getPrototypeOf(state)),
+      state,
+      ...overrides,
+    );
     return shallowEqualsPartial(state, result) ? state : result;
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -61,11 +61,6 @@
     "no-string-throw": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unused-variable": [
-      true,
-      "react"
-    ],
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "no-var-requires": true,
     "one-line": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,27 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.8.3"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha1-M+JZA9dIEYFTThLsCiXxa2/PQZ4=
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.5"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha1-kJd6jm+/a0MafcMXUu7iM78FLYA=
+
+"@babel/highlight@^7.8.3":
+  version "7.9.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha1-TptFzLgreWBycbKXmtgse2gWMHk=
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@types/jest@^19.2.2":
   version "19.2.4"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-19.2.4.tgz#543651712535962b7dc615e18e4a381fc2687442"
@@ -83,6 +104,13 @@ ansi-styles@^2.2.1:
 ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=
   dependencies:
     color-convert "^1.9.0"
 
@@ -455,7 +483,7 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -534,6 +562,15 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0, chalk@^2.3.0:
+  version "2.4.2"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^2.0.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
@@ -603,10 +640,6 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-colors@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-
 columnify@~1.5.4:
   version "1.5.4"
   resolved "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -624,7 +657,7 @@ commander@2.11.0, commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
-commander@~2.20.3:
+commander@^2.12.1, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
 
@@ -817,9 +850,14 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^3.0.0, diff@^3.2.0:
+diff@^3.0.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=
 
 doctrine@^0.7.2:
   version "0.7.2"
@@ -1394,6 +1432,11 @@ has-flag@^1.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-gulplog@^0.1.0:
   version "0.1.0"
@@ -1984,13 +2027,21 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
 js-yaml@3.x, js-yaml@^3.7.0:
   version "3.9.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3713,6 +3764,13 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
@@ -3849,9 +3907,14 @@ tsconfig@^6.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.0.0, tslib@^1.6.1, tslib@^1.7.1:
+tslib@^1.0.0:
   version "1.7.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
+
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.11.2"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
+  integrity sha1-nHnYMnLJp6rxZvc5Fclmfs3ePMk=
 
 tslint-eslint-rules@^4.0.0:
   version "4.1.1"
@@ -3861,30 +3924,35 @@ tslint-eslint-rules@^4.0.0:
     tslib "^1.0.0"
     tsutils "^1.4.0"
 
-tslint@^5.1.0:
-  version "5.6.0"
-  resolved "https://registry.npmjs.org/tslint/-/tslint-5.6.0.tgz#088aa6c6026623338650b2900828ab3edf59f6cf"
+tslint@^5.11.0:
+  version "5.20.1"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
+  integrity sha1-5AHortoBUrxE3QfmFANPP4DGe30=
   dependencies:
-    babel-code-frame "^6.22.0"
-    colors "^1.1.2"
-    commander "^2.9.0"
-    diff "^3.2.0"
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^4.0.1"
     glob "^7.1.1"
+    js-yaml "^3.13.1"
     minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     resolve "^1.3.2"
     semver "^5.3.0"
-    tslib "^1.7.1"
-    tsutils "^2.7.1"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
 
 tsutils@^1.4.0:
   version "1.9.1"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
-tsutils@^2.7.1:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=
   dependencies:
-    tslib "^1.7.1"
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3910,9 +3978,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE=
 
 uglify-js@^3.1.4:
   version "3.7.3"


### PR DESCRIPTION
Upgrades to modern toolchains. This does come with breaking `.d.ts` changes, but at this point TypeScript 3.0 is around two years old, so the upgrade cost is hopefully transparent to consumers.

A loud release note will accompany the next minor release to flag this potential incompatibility.