### PR TITLE
Add defineAction() and isType(). Deprecate TypedAction.define() and variants

### DIFF
--- a/src/TypedAction.ts
+++ b/src/TypedAction.ts
@@ -80,7 +80,12 @@ export interface TypedAction<T, E extends string = string> {
 export namespace TypedAction {
 
   /**
+   * **DEPRECATED**: As of Redoodle 2.5.0, consumers should prefer `defineAction()`
+   * over than `TypedAction.define()`. See https://github.com/palantir/redoodle/issues/35
+   *
    * Options to TypedAction.define().
+   *
+   * @deprecated
    */
   export interface DefineOptions<T> {
     /**
@@ -94,6 +99,9 @@ export namespace TypedAction {
   }
 
   /**
+   * **DEPRECATED**: As of Redoodle 2.5.0, consumers should prefer `defineAction()`
+   * over than `TypedAction.define()`. See https://github.com/palantir/redoodle/issues/35
+   *
    * One of the core functions of Redoodle, `TypedAction.define` creates a Definition
    * to manage all Redux actions of a specific type string, such as `"myapp::set_foo_value"`.
    *
@@ -117,6 +125,8 @@ export namespace TypedAction {
    * All Definitions for a Redux-enabled application MUST have unique strings.
    *
    * @param options.validatePayload
+   *
+   * @deprecated
    */
   export function define<E extends string>(type: E): <T>(options?: DefineOptions<T>) => Definition<E, T> {
     return <T>(options?: DefineOptions<T>) => {
@@ -129,6 +139,9 @@ export namespace TypedAction {
   }
 
   /**
+   * **DEPRECATED**: As of Redoodle 2.5.0, consumers should prefer `defineAction()`
+   * over than `TypedAction.define()`. See https://github.com/palantir/redoodle/issues/35
+   *
    * Similar to TypedAction.define, creates a NoPayloadDefinition for the given Action type
    * string, like `"example::clear_foo"`. In practice, actions without payloads are
    * usually of the "clear" or "invalidate" variety.
@@ -144,6 +157,8 @@ export namespace TypedAction {
    *
    *
    * All Definitions for a Redux-enabled application MUST have unique strings.
+   *
+   * @deprecated
    */
   export function defineWithoutPayload<E extends string>(type: E): () => NoPayloadDefinition<E> {
     return () => {

--- a/src/TypedActionDefinition2.ts
+++ b/src/TypedActionDefinition2.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TypedActionString } from "./TypedActionString";
+
+/**
+ * A central type of Redoodle, the TypedAction2Definition2 manages all Redux Actions
+ * of a specific type string, such as `"RemoveBar"`.
+ *
+ * - Definitions should be used to create Actions.
+ * - Definitions can be used to identify an Action using its Definition.TYPE.
+ *
+ * All Definitions for a Redux-enabled application must have unique strings.
+ */
+export type TypedActionDefinition2<E extends string, T> = {
+  /**
+   * Creates an Action of this type with the given payload and meta.
+   */
+  <M>(payload: T, meta?: M): { type: E; payload: T; meta: M };
+
+  /**
+   * The Type of a TypedAction refers to the physical `{type}` string
+   * given to matching Actions. This TypedActionString is branded
+   * with the payload type as well for e.g. TypedReducer type inferencing.
+   */
+  TYPE: TypedActionString<T, E>;
+
+  /**
+   * Hidden field used for some workflows that need to extract the payload type back out of
+   * a TypedAction definition. For example, `const payload: typeof MyAction.__PAYLOAD = { ... };`
+   * can be used to define a payload conforming to MyAction.
+   *
+   * This value should only be used for constructing Types in TypeScript. It never holds a real value.
+   * Future versions of Redoodle may throw when attempting accessing this value at runtime
+   * to catch accidental misuse.
+   */
+  __PAYLOAD: T;
+} & (T extends undefined
+  ? {
+      /**
+       * When the action has no payload type, you can simply invoke the Definition with no args
+       * to create the action `{ type: "Foo", payload: undefined }`
+       */
+    (): { type: E; payload: undefined };
+  }
+  : {});

--- a/src/__tests__/defineAction.spec.ts
+++ b/src/__tests__/defineAction.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineAction } from "../defineAction";
+
+describe("defineAction", () => {
+  it("should return actions with correct type and payload", () => {
+    const RemoveBar = defineAction("RemoveBar")<number>();
+    expect(RemoveBar(4)).toEqual({ type: "RemoveBar", payload: 4 });
+  });
+
+  it("should allow no-arg invocation for `undefined` payload definitions", () => {
+    const Reset = defineAction("Reset")();
+    expect(Reset()).toEqual({ type: "Reset", payload: undefined });
+  });
+});

--- a/src/__tests__/isType.spec.ts
+++ b/src/__tests__/isType.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineAction } from "../defineAction";
+import { isType } from "../isType";
+
+describe("isType", () => {
+  it("should return `true` for matching actions", () => {
+    const RemoveBar = defineAction("RemoveBar")<number>();
+    expect(isType({ type: "RemoveBar", payload: 4 }, RemoveBar.TYPE)).toBe(
+      true,
+    );
+  });
+
+  it("should return `false` for nonmatching actions", () => {
+    const RemoveBar = defineAction("RemoveBar")<number>();
+    expect(isType({ type: "SetBar", payload: 4 }, RemoveBar.TYPE)).toBe(false);
+  });
+});

--- a/src/defineAction.ts
+++ b/src/defineAction.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TypedActionDefinition2 } from "./TypedActionDefinition2";
+
+/**
+ * A central concept to Redoodle, a TypedAction is a stricter flavor of
+ * Action that associates a specific Action type string with a matching payload.
+ *
+ * To use TypedActions:
+ *
+ * 1. Create a Definition using `defineAction()`. For example,
+ *
+ *    ```
+ *    export const RemoveBar = defineAction("RemoveBar")<{ bar: string }>();
+ *    ```
+ *
+ * 2. Use the Definition wherever you need to create conformant actions. For example,
+ *
+ *    ```
+ *    store.dispatch(RemoveBar({ bar: "three" }));
+ *    // dispatches the action `{ type: "RemoveBar", payload: { bar: "three" } }`
+ *    ```
+ *
+ * Conforms to Flux Standard Action recommendations.
+ *
+ * @param type the action type string
+ */
+export function defineAction<E extends string>(type: E) {
+  return <T = undefined>(): TypedActionDefinition2<E, T> => {
+    const retval: TypedActionDefinition2<E, T> = function (
+      payload: T,
+      meta: any,
+    ) {
+      return arguments.length === 3
+        ? { type, payload, meta }
+        : { type, payload };
+    } as any;
+
+    retval.TYPE = type as any;
+    return retval;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ export { combineReducers } from "./combineReducers";
 export { composeReducers } from "./composeReducers";
 export { compoundActionsEnhancer } from "./compoundActionsEnhancer";
 export { createStore } from "./createStore";
+export { defineAction } from "./defineAction";
+export { isType } from "./isType";
 export { loggingMiddleware } from "./loggingMiddleware";
 export { omit } from "./omit";
 export { reduceCompoundActions } from "./reduceCompoundActions";

--- a/src/isType.ts
+++ b/src/isType.ts
@@ -1,0 +1,10 @@
+import { Action } from "./Action";
+import { TypedAction } from "./TypedAction";
+import { TypedActionString } from "./TypedActionString";
+
+export function isType<T>(
+  action: Action,
+  type: TypedActionString<T>,
+): action is TypedAction<T> {
+  return action.type === type;
+}


### PR DESCRIPTION
This PR deprecates the old `TypedAction.create()` in favor of the near-equivalent `defineAction()`. This change was done for a few reasons:

- Fewer closures required per action definition, which ultimately speeds up boot cost of action definitions by a factor of ~3.
- Better tree-shaking in modern webpack toolchains

For consumers, the following migration guide should be helpful:

1. All usages of `TypedAction.define()` and `TypedAction.defineWithoutPayload()` should be migrated to `defineAction()`.
2. All usages of `FooTypedAction.create(...)` and `FooTypedAction.createWithMeta(...)` should be migrated to `FooDefinedAction(...)`.
3. All usages of `FooTypedAction.is(action)` should be migrated to `isType(action, FooDefinedAction.TYPE)`

The issue https://github.com/palantir/redoodle/issues/35 will be used to track migration guides or pain related to this change.