### PR TITLE
Prefer plain loops over for-of and for-in. Remove usage of `delete`

### DIFF
--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -30,7 +30,8 @@ function reduce<S>(
 ) {
   let newState: S | undefined = undefined;
 
-  for (const key of reducerKeys) {
+  for (let i = 0; i < reducerKeys.length; i++) {
+    const key = reducerKeys[i];
     const statePart = state[key];
     const newStatePart = reducerMap[key](statePart, action);
     if (newStatePart !== statePart) {

--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -22,28 +22,30 @@ import { ReducerMap } from "./ReducerMap";
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-function reduce<S>(state: S, action: Action, reducerMap: ReducerMap<S>) {
+function reduce<S>(
+  state: S,
+  action: Action,
+  reducerMap: ReducerMap<S>,
+  reducerKeys: (keyof S)[],
+) {
   let newState: S | undefined = undefined;
 
-  for (const key in reducerMap) {
-    if (!hasOwnProperty.call(reducerMap, key)) {
-      continue;
-    }
-
+  for (const key of reducerKeys) {
     const statePart = state[key];
     const newStatePart = reducerMap[key](statePart, action);
     if (newStatePart !== statePart) {
       if (!newState) {
-        newState = __assign(Object.create(Object.getPrototypeOf(state)), state) as S;
+        newState = __assign(
+          Object.create(Object.getPrototypeOf(state)),
+          state,
+        ) as S;
       }
 
       newState[key] = newStatePart;
     }
   }
 
-  return newState !== undefined
-      ? newState
-      : state;
+  return newState !== undefined ? newState : state;
 }
 
 function verifySameShape<S>(state: S, reducerMap: ReducerMap<S>) {
@@ -52,7 +54,9 @@ function verifySameShape<S>(state: S, reducerMap: ReducerMap<S>) {
       hasOwnProperty.call(state, key) &&
       !hasOwnProperty.call(reducerMap, key)
     ) {
-      throw new Error(`mismatched shapes in combineReducers(): reducers missing '${key}'`);
+      throw new Error(
+        `mismatched shapes in combineReducers(): reducers missing '${key}'`,
+      );
     }
   }
 
@@ -61,7 +65,9 @@ function verifySameShape<S>(state: S, reducerMap: ReducerMap<S>) {
       hasOwnProperty.call(reducerMap, key) &&
       !hasOwnProperty.call(state, key)
     ) {
-      throw new Error(`mismatched shapes in combineReducers(): state missing '${key}'`);
+      throw new Error(
+        `mismatched shapes in combineReducers(): state missing '${key}'`,
+      );
     }
   }
 }
@@ -86,17 +92,17 @@ function verifySameShape<S>(state: S, reducerMap: ReducerMap<S>) {
  */
 export function combineReducers<S>(reducerMap: ReducerMap<S>): Reducer<S> {
   let hasVerifiedShape = false;
+  const reducerKeys = Object.keys(reducerMap) as (keyof S)[];
+
   return (state: S, action: Action) => {
     if (
       typeof process === "undefined" ||
       process.env.NODE_ENV !== "production"
     ) {
-      if (
-        state === undefined ||
-        state === null ||
-        typeof state !== "object"
-      ) {
-        throw new Error("combineReducers() requires object state; received " + state);
+      if (state === undefined || state === null || typeof state !== "object") {
+        throw new Error(
+          "combineReducers() requires object state; received " + state,
+        );
       }
 
       if (!hasVerifiedShape) {
@@ -105,6 +111,6 @@ export function combineReducers<S>(reducerMap: ReducerMap<S>): Reducer<S> {
       }
     }
 
-    return reduce(state, action, reducerMap);
+    return reduce(state, action, reducerMap, reducerKeys);
   };
 }

--- a/src/internal/utils/shallowEqualsPartial.ts
+++ b/src/internal/utils/shallowEqualsPartial.ts
@@ -15,11 +15,16 @@
  * limitations under the License.
  */
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 export function shallowEqualsPartial(state: any, partial: any): boolean {
   const partialKeys = Object.keys(partial);
   for (let i = 0; i < partialKeys.length; i++) {
     const key = partialKeys[i];
-    if (partial[key] !== state[key]) {
+    const partialValue = partial[key];
+    if (
+      state[key] !== partialValue ||
+      (partialValue === undefined && !hasOwnProperty.call(state, key))
+    ) {
       return false;
     }
   }

--- a/src/internal/utils/shallowEqualsPartial.ts
+++ b/src/internal/utils/shallowEqualsPartial.ts
@@ -15,22 +15,8 @@
  * limitations under the License.
  */
 
-const hasOwnProperty = Object.prototype.hasOwnProperty;
-
 export function shallowEqualsPartial(state: any, partial: any): boolean {
-  if (state === partial) {
-    return true;
-  }
-
-  for (const key in partial) {
-    if (!hasOwnProperty.call(partial, key)) {
-      continue;
-    }
-
-    if (!hasOwnProperty.call(state, key)) {
-      return false;
-    }
-
+  for (const key of Object.keys(partial)) {
     if (partial[key] !== state[key]) {
       return false;
     }

--- a/src/internal/utils/shallowEqualsPartial.ts
+++ b/src/internal/utils/shallowEqualsPartial.ts
@@ -16,7 +16,9 @@
  */
 
 export function shallowEqualsPartial(state: any, partial: any): boolean {
-  for (const key of Object.keys(partial)) {
+  const partialKeys = Object.keys(partial);
+  for (let i = 0; i < partialKeys.length; i++) {
+    const key = partialKeys[i];
     if (partial[key] !== state[key]) {
       return false;
     }

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -19,9 +19,9 @@ import { __assign } from "tslib";
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-function anyDefined(state: any, keys: string[]): boolean {
-  for (const key of keys) {
-    if (hasOwnProperty.call(state, key)) {
+function hasAny(state: any, keys: string[]): boolean {
+  for (let i = 0; i < keys.length; i++) {
+    if (hasOwnProperty.call(state, keys[i])) {
       return true;
     }
   }
@@ -41,14 +41,20 @@ function anyDefined(state: any, keys: string[]): boolean {
  *      a prototype if the input `state` has no prototype.
  */
 export function omit<S extends {[key: string]: any}>(state: S, keys: (keyof S)[]): S {
-  if (!anyDefined(state, keys as string[])) {
+  if (!hasAny(state, keys as string[])) {
     return state;
   }
 
-  const result = __assign(Object.create(Object.getPrototypeOf(state)), state);
-  for (const key of keys) {
-    delete result[key];
+  const omitSet = new Set(keys);
+  const stateKeys = Object.keys(state) as (keyof S)[];
+  const retval: S = {} as S;
+
+  for (let i = 0; i < stateKeys.length; i++) {
+    const key = stateKeys[i];
+    if (!omitSet.has(key)) {
+      retval[key] = state[key];
+    }
   }
 
-  return result;
+  return retval;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "importHelpers": true,
-    "lib": [
-      "dom",
-      "es5"
-    ],
+    "lib": ["es2015"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -15,9 +12,5 @@
     "strict": true,
     "target": "es5"
   },
-  "exclude": [
-    "_book",
-    "node_modules",
-    "lib"
-  ]
+  "exclude": ["_book", "node_modules", "lib"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "importHelpers": true,
-    "lib": ["es2015"],
+    "lib": ["dom", "es2015"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
Brief modernization pass to avoid common performance pitfalls. In short:

- For-in loops should never be used for the workflows Redoodle focuses on, as a plain `for` loop through Object.keys() will far outperform it. https://jsperf.com/object-keys-vs-for-in-with-closure/3
- Usage of `delete` pretty quickly causes Chrome deopt or other subpar object packing
- Avoid for-of loops because we target ES5. The `tsc` downlevel iteration transpiler emits pretty inoptimal bytecode.