### PR TITLE
Simplify prototype handling

### DIFF
--- a/src/__tests__/combineReducers.spec.ts
+++ b/src/__tests__/combineReducers.spec.ts
@@ -17,10 +17,6 @@
 
 import { Action, Reducer, combineReducers } from "../index";
 
-interface A {
-  a: number;
-}
-
 function constant(payload: number): Action {
   return {
     type: "test::constant",
@@ -74,38 +70,6 @@ describe("combineReducers", () => {
       expect(() =>
         reducer(undefined as any, { type: "redoodle/test/INIT", payload: {} }),
       ).toThrow();
-    });
-  });
-
-  describe("prototype defense", () => {
-    it("should properly reduce a subkey 'hasOwnProperty'", () => {
-      const reducer = combineReducers({ hasOwnProperty: add });
-      expect(reducer({ hasOwnProperty: 4 }, constant(5))).toEqual({
-        hasOwnProperty: 9,
-      });
-    });
-
-    it("should return an object with Object prototype when given state with Object prototype", () => {
-      const reducer = combineReducers({ a: add });
-      expect(Object.getPrototypeOf(reducer({ a: 4 }, constant(5)))).toBe(
-        Object.prototype,
-      );
-    });
-
-    it("should reduce an initial state with `null` prototype", () => {
-      const initialState = Object.create(null) as A;
-      initialState.a = 4;
-      const reducer = combineReducers({ a: add });
-      expect(reducer(initialState, constant(5))).toEqual({ a: 9 });
-    });
-
-    it("should return an object with null prototype if input state has null prototype", () => {
-      const initialState = Object.create(null) as A;
-      initialState.a = 4;
-      const reducer = combineReducers({ a: add });
-      expect(Object.getPrototypeOf(reducer(initialState, constant(5)))).toEqual(
-        null,
-      );
     });
   });
 });

--- a/src/__tests__/setWith.spec.ts
+++ b/src/__tests__/setWith.spec.ts
@@ -26,10 +26,6 @@ interface B {
   b: string;
 }
 
-function clean<T>(obj: T): T {
-  return __assign(Object.create(null), obj);
-}
-
 describe("setWith", () => {
   describe("when passed an object that overrides a key with a different value", () => {
     let state: A & B, result: A & B;
@@ -96,26 +92,6 @@ describe("setWith", () => {
       const state = { a: undefined };
       const result = setWith(state, { a: undefined });
       expect(result).toBe(state);
-    });
-  });
-
-  describe("null prototype handling", () => {
-    it("should return source object on no-op update", () => {
-      const state = clean({ a: "hello", b: "world" });
-      const result = setWith(state, { a: "hello" });
-      expect(result).toBe(state);
-    });
-
-    it("should correctly apply update", () => {
-      const state = clean({ a: "hello", b: "world" });
-      const result = setWith(state, { a: "goodbye" });
-      expect(result).toEqual({ a: "goodbye", b: "world" });
-    });
-
-    it("should return object with no prototype on update", () => {
-      const state = clean({ a: "hello", b: "world" });
-      const result = setWith(state, { a: "goodbye" });
-      expect(Object.getPrototypeOf(result)).toBeNull();
     });
   });
 });

--- a/src/combineReducers.ts
+++ b/src/combineReducers.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { __assign } from "tslib";
 import { Action } from "./Action";
 import { Reducer } from "./Reducer";
 import { ReducerMap } from "./ReducerMap";
@@ -36,10 +35,7 @@ function reduce<S>(
     const newStatePart = reducerMap[key](statePart, action);
     if (newStatePart !== statePart) {
       if (!newState) {
-        newState = __assign(
-          Object.create(Object.getPrototypeOf(state)),
-          state,
-        ) as S;
+        newState = { ...state };
       }
 
       newState[key] = newStatePart;

--- a/src/setWith.ts
+++ b/src/setWith.ts
@@ -83,18 +83,10 @@ export function setWith(state: any, ...overrides: any[]) {
     if (shallowEqualsPartial(state, overrides[0])) {
       return state;
     } else {
-      return __assign(
-        Object.create(Object.getPrototypeOf(state)),
-        state,
-        overrides[0],
-      );
+      return __assign({}, state, overrides[0]);
     }
   } else {
-    const result = __assign(
-      Object.create(Object.getPrototypeOf(state)),
-      state,
-      ...overrides,
-    );
+    const result = __assign({}, state, ...overrides);
     return shallowEqualsPartial(state, result) ? state : result;
   }
 }


### PR DESCRIPTION
This PR simplifies Redoodle's handling of Prototypes within `combineReducers()` and `setWith()`.

In the original version of Redoodle, special care was given to maintain the prototype given by objects. This was in line with an attempt to have as few surprises as possible when integrating with Redoodle.

However, in the last four years, prototype handling has basically vanished. In fact, the new spread operator `{...a}` always returns an object with the `Object` prototype, rather than using the same prototype as `a`, so I would argue that diverging from that logic in `setWith()` would be surprising to the consumer.

This change should be transparent to every workflow. If anybody has an advanced use that was broken by this change, please file an issue.