### PR TITLE
Remove stray tsdoc tag

### DIFF
--- a/src/TypedAction.ts
+++ b/src/TypedAction.ts
@@ -123,8 +123,6 @@ export namespace TypedAction {
    *
    * All Definitions for a Redux-enabled application MUST have unique strings.
    *
-   * @param options.validatePayload
-   *
    * @deprecated
    */
   export function define<E extends string>(


### PR DESCRIPTION
Fixes #6

There was a stray `@param options.validatePayload` that wasn't actually referring to anything. It has been removed.