### PR TITLE
Typed reducer definition handler

### DIFF
--- a/src/TypedReducer.ts
+++ b/src/TypedReducer.ts
@@ -72,7 +72,10 @@ export namespace TypedReducer {
      * Alias for withHandler that takes the whole action definition rather than just the typ string.
      */
     withDefinitionHandler<T, E extends string>(
-      type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T> | TypedAction.NoPayloadDefinition<E>,
+      type:
+        | TypedActionDefinition2<E, T>
+        | TypedAction.Definition<E, T>
+        | TypedAction.NoPayloadDefinition<E>,
       handler: (state: S, payload: T, meta: any | undefined) => S,
     ): this;
 

--- a/src/TypedReducer.ts
+++ b/src/TypedReducer.ts
@@ -72,7 +72,7 @@ export namespace TypedReducer {
      * Alias for withHandler that takes the whole action definition rather than just the typ string.
      */
     withDefinitionHandler<T, E extends string>(
-      type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T>,
+      type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T> | TypedAction.NoPayloadDefinition<E>,
       handler: (state: S, payload: T, meta: any | undefined) => S,
     ): this;
 

--- a/src/TypedReducer.ts
+++ b/src/TypedReducer.ts
@@ -69,7 +69,7 @@ export namespace TypedReducer {
     ): this;
 
     /**
-     * Alias for withHandler that takes the whole action definition rather than just the typ string.
+     * Alias for withHandler that takes the whole action definition rather than just the type string.
      */
     withDefinitionHandler<T, E extends string>(
       type:

--- a/src/TypedReducer.ts
+++ b/src/TypedReducer.ts
@@ -18,9 +18,9 @@
 import { Action } from "./Action";
 import { Reducer } from "./Reducer";
 import { TypedAction } from "./TypedAction";
+import { TypedActionDefinition2 } from "./TypedActionDefinition2";
 import { TypedActionString } from "./TypedActionString";
 import { TypedReducerBuilderImpl } from "./internal/TypedReducerBuilderImpl";
-import { TypedActionDefinition2 } from "./TypedActionDefinition2";
 
 /**
  * Important utility to help build Redux Reducer functions

--- a/src/TypedReducer.ts
+++ b/src/TypedReducer.ts
@@ -20,6 +20,7 @@ import { Reducer } from "./Reducer";
 import { TypedAction } from "./TypedAction";
 import { TypedActionString } from "./TypedActionString";
 import { TypedReducerBuilderImpl } from "./internal/TypedReducerBuilderImpl";
+import { TypedActionDefinition2 } from "./TypedActionDefinition2";
 
 /**
  * Important utility to help build Redux Reducer functions
@@ -64,6 +65,14 @@ export namespace TypedReducer {
      */
     withHandler<T>(
       type: TypedActionString<T>,
+      handler: (state: S, payload: T, meta: any | undefined) => S,
+    ): this;
+
+    /**
+     * Alias for withHandler that takes the whole action definition rather than just the typ string.
+     */
+    withDefinitionHandler<T, E extends string>(
+      type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T>,
       handler: (state: S, payload: T, meta: any | undefined) => S,
     ): this;
 

--- a/src/__tests__/TypedReducer.spec.ts
+++ b/src/__tests__/TypedReducer.spec.ts
@@ -26,6 +26,7 @@ describe("TypedReducer", () => {
   const Log = TypedAction.define("test::log")<string[]>();
   const Count = TypedAction.define("test::count")<number>();
   const Reset = TypedAction.define("test::reset")<number>();
+  const One = TypedAction.defineWithoutPayload("test::one")();
 
   it("should return a reducer function", () => {
     const reducer = TypedReducer.builder().build();
@@ -58,16 +59,6 @@ describe("TypedReducer", () => {
   it("should allow specifying payload-only handlers", () => {
     const reducer = TypedReducer.builder<CountState>()
       .withHandler(Count.TYPE, (state, toAdd) => ({
-        total: state.total + toAdd,
-      }))
-      .build();
-
-    expect(reducer({ total: 5 }, Count.create(3))).toEqual({ total: 8 });
-  });
-
-  it("should allow specifying definition payload-only handlers", () => {
-    const reducer = TypedReducer.builder<CountState>()
-      .withDefinitionHandler(Count, (state, toAdd) => ({
         total: state.total + toAdd,
       }))
       .build();
@@ -116,5 +107,25 @@ describe("TypedReducer", () => {
     expect(reducer({ total: 8 }, Log.create(["foobar", "world"]))).toEqual({
       total: 19,
     });
+  });
+
+  it("should allow specifying definition payload-only handlers", () => {
+    const reducer = TypedReducer.builder<CountState>()
+      .withDefinitionHandler(Count, (state, toAdd) => ({
+        total: state.total + toAdd,
+      }))
+      .build();
+
+    expect(reducer({ total: 5 }, Count.create(3))).toEqual({ total: 8 });
+  });
+
+  it("should allow specifying definition without payload", () => {
+    const reducer = TypedReducer.builder<CountState>()
+      .withDefinitionHandler(One, () => ({
+        total: 1,
+      }))
+      .build();
+
+    expect(reducer({ total: 10 }, One.create())).toEqual({ total: 1 });
   });
 });

--- a/src/__tests__/TypedReducer.spec.ts
+++ b/src/__tests__/TypedReducer.spec.ts
@@ -65,6 +65,16 @@ describe("TypedReducer", () => {
     expect(reducer({ total: 5 }, Count.create(3))).toEqual({ total: 8 });
   });
 
+  it("should allow specifying definition payload-only handlers", () => {
+    const reducer = TypedReducer.builder<CountState>()
+      .withDefinitionHandler(Count, (state, toAdd) => ({
+        total: state.total + toAdd,
+      }))
+      .build();
+
+    expect(reducer({ total: 5 }, Count.create(3))).toEqual({ total: 8 });
+  });
+
   it("should only invoke handlers for existing actions", () => {
     const reducer = TypedReducer.builder<CountState>()
       .withActionHandler(

--- a/src/internal/TypedReducerBuilderImpl.ts
+++ b/src/internal/TypedReducerBuilderImpl.ts
@@ -20,6 +20,7 @@ import { Reducer } from "../Reducer";
 import { TypedAction } from "../TypedAction";
 import { TypedActionString } from "../TypedActionString";
 import { TypedReducer } from "../TypedReducer";
+import { TypedActionDefinition2 } from "../TypedActionDefinition2";
 
 export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
   private typedHandlers: { [type: string]: Reducer<S> } = {};
@@ -33,6 +34,13 @@ export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
       return handler(state, action.payload, action.meta);
     });
   }
+
+  withDefinitionHandler<T, E extends string = string>(
+    type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T>,
+    handler: (state: S, payload: T, meta: any | undefined) => S,
+    ): this {
+      return this.withHandler(type.TYPE, handler);
+    }
 
   withActionHandler<T, E extends string = string>(
     type: TypedActionString<T, E>,

--- a/src/internal/TypedReducerBuilderImpl.ts
+++ b/src/internal/TypedReducerBuilderImpl.ts
@@ -18,9 +18,9 @@
 import { Action } from "../Action";
 import { Reducer } from "../Reducer";
 import { TypedAction } from "../TypedAction";
+import { TypedActionDefinition2 } from "../TypedActionDefinition2";
 import { TypedActionString } from "../TypedActionString";
 import { TypedReducer } from "../TypedReducer";
-import { TypedActionDefinition2 } from "../TypedActionDefinition2";
 
 export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
   private typedHandlers: { [type: string]: Reducer<S> } = {};

--- a/src/internal/TypedReducerBuilderImpl.ts
+++ b/src/internal/TypedReducerBuilderImpl.ts
@@ -36,11 +36,14 @@ export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
   }
 
   withDefinitionHandler<T, E extends string = string>(
-    type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T> | TypedAction.NoPayloadDefinition<E>,
+    type:
+      | TypedActionDefinition2<E, T>
+      | TypedAction.Definition<E, T>
+      | TypedAction.NoPayloadDefinition<E>,
     handler: (state: S, payload: T, meta: any | undefined) => S,
-    ): this {
-      return this.withHandler(type.TYPE, handler);
-    }
+  ): this {
+    return this.withHandler(type.TYPE, handler);
+  }
 
   withActionHandler<T, E extends string = string>(
     type: TypedActionString<T, E>,

--- a/src/internal/TypedReducerBuilderImpl.ts
+++ b/src/internal/TypedReducerBuilderImpl.ts
@@ -36,7 +36,7 @@ export class TypedReducerBuilderImpl<S> implements TypedReducer.Builder<S> {
   }
 
   withDefinitionHandler<T, E extends string = string>(
-    type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T>,
+    type: TypedActionDefinition2<E, T> | TypedAction.Definition<E, T> | TypedAction.NoPayloadDefinition<E>,
     handler: (state: S, payload: T, meta: any | undefined) => S,
     ): this {
       return this.withHandler(type.TYPE, handler);


### PR DESCRIPTION
instead of

`.withHandler(createTypedAction.TYPE, myHandler)`

can do

`.withDefinitionHandler(createTypedAction, myHandler)`