### PR TITLE
Add type compatibility with Redux@4 by adding Observable support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gitbook-cli": "^2.3.0",
     "jest": "^19.0.2",
     "prettier": "^2.0.5",
-    "redux": "^4.0.0",
+    "redux": "^4.0.5",
     "ts-jest": "^19.0.13",
     "tslint": "^5.11.0",
     "tslint-eslint-rules": "^4.0.0",

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -17,11 +17,13 @@
 
 import { Dispatch } from "./Dispatch";
 import { Reducer } from "./Reducer";
+import { _ObservableLike } from "./_observableCompat";
 
 /**
  * Standard Redux Store type.
  */
 export interface Store<S> {
+  [Symbol.observable](): _ObservableLike<S>;
   dispatch: Dispatch;
   getState: () => S;
   subscribe: (listener: () => void) => () => void;

--- a/src/__tests__/typeCompatibility.spec.ts
+++ b/src/__tests__/typeCompatibility.spec.ts
@@ -1,0 +1,14 @@
+import type * as redux from "redux";
+import { createStore } from "../createStore";
+
+interface State {
+  foo: number;
+}
+
+// @ts-ignore
+function test() {
+  // we actually only need this to compile, so there's no real "test" here
+  const reduxStore: redux.Store<State> = createStore<State>((s: State) => s, {
+    foo: 5,
+  });
+}

--- a/src/__tests__/typeCompatibility.spec.ts
+++ b/src/__tests__/typeCompatibility.spec.ts
@@ -9,12 +9,11 @@ function __unused(_value: any) {
   // noop
 }
 
-// @ts-ignore since this function is never used
-function test() {
+it("Redoodle Store should be compatible with Redux Store typing", () => {
   // we actually only need this to compile, so there's no real "test" here
   const reduxStore: redux.Store<State> = createStore<State>((s: State) => s, {
     foo: 5,
   });
 
   __unused(reduxStore);
-}
+});

--- a/src/__tests__/typeCompatibility.spec.ts
+++ b/src/__tests__/typeCompatibility.spec.ts
@@ -5,10 +5,16 @@ interface State {
   foo: number;
 }
 
-// @ts-ignore
+function __unused(_value: any) {
+  // noop
+}
+
+// @ts-ignore since this function is never used
 function test() {
   // we actually only need this to compile, so there's no real "test" here
   const reduxStore: redux.Store<State> = createStore<State>((s: State) => s, {
     foo: 5,
   });
+
+  __unused(reduxStore);
 }

--- a/src/_observableCompat.ts
+++ b/src/_observableCompat.ts
@@ -1,0 +1,27 @@
+
+/**
+ * Minimal interface to support Observer integration for Redoodle.
+ * Redoodle is not designed as an Observable engine itself. Integration is included only
+ * for compatibility with core Redux, which recently added its own Observer support.
+ */
+export type _ObserverLike<T> = {
+  next?(value: T): void
+}
+
+/**
+ * Minimal interface to support Observable integration for Redoodle.
+ * Redoodle is not designed as an Observable engine itself. Integration is included only
+ * for compatibility with core Redux, which recently added its own Observer support.
+ */
+export interface _ObservableLike<T> {
+  /**
+   * The minimal observable subscription method.
+   * @param {Object} observer Any object that can be used as an observer.
+   * The observer object should have a `next` method.
+   * @returns {subscription} An object with an `unsubscribe` method that can
+   * be used to unsubscribe the observable from the store, and prevent further
+   * emission of values from the observable.
+   */
+  subscribe: (observer: _ObserverLike<T>) => { unsubscribe: () => void }
+  [Symbol.observable](): _ObservableLike<T>;
+}

--- a/src/compoundActionsEnhancer.ts
+++ b/src/compoundActionsEnhancer.ts
@@ -31,11 +31,9 @@ export function compoundActionsEnhancer(): StoreEnhancer {
     return (reducer, initialState) => {
       const store = next(reduceCompoundActions(reducer), initialState);
       return {
-        dispatch: store.dispatch,
-        getState: store.getState,
+        ...store,
         replaceReducer: (newReducer) =>
           store.replaceReducer(reduceCompoundActions(newReducer)),
-        subscribe: store.subscribe,
       };
     };
   };

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
     "node_modules/tslint-eslint-rules/dist/rules"
   ],
   "rules": {
-    "class-name": true,
+    "class-name": false,
     "comment-format": [
       true,
       "check-space"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,9 +2392,10 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
-loose-envify@^1.1.0:
+loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
@@ -3407,11 +3408,12 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
+redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
   dependencies:
-    loose-envify "^1.1.0"
+    loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
 
 regenerator-runtime@^0.10.0:


### PR DESCRIPTION
Redoodle isn't meant to be a fully-fledged Redux engine, and in fact it's impossible to guarantee that over time (Redux may add a feature that Redoodle doesn't yet support). However, recent Redux upgrades have caused pain on consumers as Redoodle's Store type may not be compatible with Redux's Store type, causing confusing messages and "will this work?" feeling from those doing upgrades.

This PR adds support for Redux 4.0.5 Store:

* Add `[Symbol.observable]()` integration
* Add tests to guarantee type compatibility
