### PR TITLE
type no-arg actions correctly when payload is void

### DIFF
--- a/src/TypedActionDefinition2.ts
+++ b/src/TypedActionDefinition2.ts
@@ -49,7 +49,7 @@ export type TypedActionDefinition2<E extends string, T> = {
    * to catch accidental misuse.
    */
   __PAYLOAD: T;
-} & (T extends undefined
+} & (T extends void
   ? {
       /**
        * When the action has no payload type, you can simply invoke the Definition with no args


### PR DESCRIPTION
`void` does not extend `undefined`, so actions typed as `defineAction("name")<void>()` get typed as `(payload: void) => void`, rather than `() => void`. Arguably `(payload: void) => void` should be treated identically to `() => void` at the typescript level, but in the meantime this improves the typing behavior.

This change should be fairly safe since `undefined extends void`, so this should only affect consumers that type actions as `void` (I believe)