### PR TITLE
Fix prettier setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           at: ./
       - run:
           name: prettier
-          command: ./node_modules/.bin/prettier --check src/**/*
+          command: ./node_modules/.bin/prettier --check "src/**/*"
 
   publish:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /.idea/
-/.vscode/
 /_book/
 /node_modules/
 /lib/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "docs:prepare": "gitbook install",
     "docs:build": "yarn docs:prepare && gitbook build -g palantir/redoodle",
     "docs:watch": "yarn docs:prepare && gitbook serve -g palantir/redoodle",
-    "docs:publish": "yarn docs:clean && yarn docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:palantir/redoodle gh-pages --force"
+    "docs:publish": "yarn docs:clean && yarn docs:build && cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:palantir/redoodle gh-pages --force",
+    "prettier:write": "prettier --write \"src/**/*\""
   },
   "dependencies": {
     "tslib": "^1.8.1"

--- a/src/PayloadOf.ts
+++ b/src/PayloadOf.ts
@@ -1,4 +1,3 @@
-
 import { TypedAction } from "./TypedAction";
 import { TypedActionDefinition2 } from "./TypedActionDefinition2";
 

--- a/src/_observableCompat.ts
+++ b/src/_observableCompat.ts
@@ -1,12 +1,11 @@
-
 /**
  * Minimal interface to support Observer integration for Redoodle.
  * Redoodle is not designed as an Observable engine itself. Integration is included only
  * for compatibility with core Redux, which recently added its own Observer support.
  */
 export type _ObserverLike<T> = {
-  next?(value: T): void
-}
+  next?(value: T): void;
+};
 
 /**
  * Minimal interface to support Observable integration for Redoodle.
@@ -22,6 +21,6 @@ export interface _ObservableLike<T> {
    * be used to unsubscribe the observable from the store, and prevent further
    * emission of values from the observable.
    */
-  subscribe: (observer: _ObserverLike<T>) => { unsubscribe: () => void }
+  subscribe: (observer: _ObserverLike<T>) => { unsubscribe: () => void };
   [Symbol.observable](): _ObservableLike<T>;
 }

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -123,7 +123,7 @@ export function createStore<S>(
     },
     [Symbol.observable]() {
       return observable;
-    }
+    },
   };
 
   return {


### PR DESCRIPTION
The prettier check was passing despite failing files – the reason was because the glob `src/**/*` only matched files in subdirectories of `src` when running in bash on Circle. Locally, I was seeing prettier (correctly) fail, and it's because zsh expanded the glob differently to include all files in `src`. Throwing the glob in quotes has prettier do the globbing, so it will work as expected.

This PR also fixes current violations of prettier, and recommends the vscode prettier extension + turns on formatOnSave in the workspace settings.