### PR TITLE
fix symbol-observable typing issue

### DIFF
--- a/changelog/@unreleased/pr-79.v2.yml
+++ b/changelog/@unreleased/pr-79.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix symbol-observable typing issue that caused Typescript compilation
+    to fail for consumers that don't depend on `redux`
+  links:
+  - https://github.com/palantir/redoodle/pull/79
+  - https://github.com/palantir/redoodle/issues/63

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,4 @@ export { omit } from "./omit";
 export { reduceCompoundActions } from "./reduceCompoundActions";
 export { setWith } from "./setWith";
 export type { PayloadOf } from "./PayloadOf";
+export * from "./symbol-observable";

--- a/src/symbol-observable.ts
+++ b/src/symbol-observable.ts
@@ -1,0 +1,14 @@
+/**
+ * We get this type filled in globally from the symbol-observable package, but if consumers of
+ * redoodle don't consume either symbol-observable or redux (which also fills in this global type),
+ * then consumers of redoodle will fail Typescript compilation without skipLibCheck turned on.
+ * Filling the type in here so that it is emitted in redoodle's type declaration files.
+ */
+
+declare global {
+  export interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
+export {};


### PR DESCRIPTION
Fixes #63

We have a dependency on `symbol-observable`, which declares an `observable: symbol` property on the global `SymbolConstructor`: https://github.com/benlesh/symbol-observable/blob/16c66c24fff07c2a34d74475551b213863249376/index.d.ts#L4-L8. That makes this compile properly within redoodle: https://github.com/palantir/redoodle/blob/5992b831e57271eac2cf03c7277c5fac9a62bafc/src/_observableCompat.ts#L26

The issue is that if the consumer of redoodle doesn’t depend on `symbol-observable` ([or `redux`, which also declares `observable` on the `SymbolConstructor`](https://github.com/reduxjs/redux/blob/80bda95d58f46fb5f6cbf6996ea87d1dcf58a602/src/utils/symbol-observable.ts#L1-L5)), then they get a type error because `Symbol.observable` doesn’t exist in the global typings.

It seems like the best option here is to have `redoodle` declare `observable: symbol` on the `SymbolConstructor` in its own typings, so that consumers don’t have issues with `skipLibCheck: false`.